### PR TITLE
Replace Deprecated Encoding Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-    @version    1.0.0
+    @version    1.0.1
     @date       2014-05-14
     @stability  3 - Stable
 

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 
 /*
-* @version    1.0.0
-* @date       2014-05-14
+* @version    1.0.1
+* @date       2014-08-04
 * @stability  3 - Stable
 * @author     Lauri Rooden <lauri@rooden.ee>
 * @license    MIT License
@@ -17,13 +17,12 @@
 this.cookie = function(name, value, ttl, path, domain, secure) {
 
 	if (arguments.length > 1) {
-		return document.cookie = name + "=" + escape(value) +
+		return document.cookie = name + "=" + encodeURIComponent(value) +
 			(ttl ? "; expires=" + new Date(+new Date()+(ttl*1000)).toUTCString() : "") +
 			(path   ? "; path=" + path : "") +
 			(domain ? "; domain=" + domain : "") +
 			(secure ? "; secure" : "")
 	}
 
-	return unescape((("; "+document.cookie).split("; "+name+"=")[1]||"").split(";")[0])
+	return decodeURIComponent((("; "+document.cookie).split("; "+name+"=")[1]||"").split(";")[0])
 }
-

--- a/min.js
+++ b/min.js
@@ -1,2 +1,2 @@
 /*! litejs.com/MIT-LICENSE.txt */
-this.cookie=function(a,e,b,c,d,f){return 1<arguments.length?document.cookie=a+"="+escape(e)+(b?"; expires="+(new Date(+new Date+1E3*b)).toUTCString():"")+(c?"; path="+c:"")+(d?"; domain="+d:"")+(f?"; secure":""):unescape((("; "+document.cookie).split("; "+a+"=")[1]||"").split(";")[0])};
+this.cookie=function(e,t,n,r,i,s){if(arguments.length>1){return document.cookie=e+"="+encodeURIComponent(t)+(n?"; expires="+(new Date(+(new Date)+n*1e3)).toUTCString():"")+(r?"; path="+r:"")+(i?"; domain="+i:"")+(s?"; secure":"")}return decodeURIComponent((("; "+document.cookie).split("; "+e+"=")[1]||"").split(";")[0])};


### PR DESCRIPTION
Replaced [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape) `escape` and `unescape` functions with newer `encodeURIComponent` and `decodeURIComponent`. Didn't update the package information in `package.json` and ran it through a pretty rudimentary minimizer so you might want to go ahead and update those as well if you incorporate these changes.

Cheers!
Alex
